### PR TITLE
Add Stat based on MLST command

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -30,6 +30,8 @@ const (
 // Time format used by the MDTM and MFMT commands
 const timeFormat = "20060102150405"
 
+var ErrNotSupported = errors.New("Not supported by remote FTP server")
+
 // ServerConn represents the connection to a remote FTP server.
 // A single connection only supports one in-flight data connection.
 // It is not safe to be called concurrently.
@@ -652,6 +654,35 @@ func (c *ServerConn) List(path string) (entries []*Entry, err error) {
 
 	err = scanner.Err()
 	return entries, err
+}
+
+// Stat issues an MLST command which returns info for a single entry
+func (c *ServerConn) Stat(path string) (entry *Entry, err error) {
+	if !c.mlstSupported {
+		return nil, ErrNotSupported
+	}
+
+	cmd := "MLST"
+	parser := parseRFC3659ListLine
+
+	space := " "
+	if path == "" {
+		space = ""
+	}
+
+	_, msg, errCmd := c.cmd(StatusRequestedFileActionOK, "%s%s%s", cmd, space, path)
+	if errCmd != nil {
+		return nil, errCmd
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(msg))
+	for scanner.Scan() {
+		parseEntry, parseErr := parser(strings.TrimLeft(scanner.Text(), " "), time.Now(), c.options.location)
+		if parseErr == nil {
+			return parseEntry, parseErr
+		}
+	}
+	return nil, scanner.Err()
 }
 
 // IsTimePreciseInList returns true if client and server support the MLSD


### PR DESCRIPTION
This PR expose the MLST command that allows returning the metadata of a file without relying on a list.

The returned `msg` has the following format:

```
C> MLST
S> 250-Begin
S>  type=dir;unique=AQkAAAAAAAABCAAA; /
S> 250 End.
```

https://datatracker.ietf.org/doc/html/rfc3659#section-7.7.5

I was not sure how to handles the "begin/end", it looks like in "List" it is ignored because it fails the parsing.

There is a slight difference with MLSD apparently because the file content is prefixed by a whitespace.

The idea for this function is to be used in `findItem` when supported to avoid an unnecessary listing to retrieve an item which I'm currently trying to implement.

Sorry for the lack of test there was nothing bootstrapped to add a test easily